### PR TITLE
Exclude test data from GitHub language statistics.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/data/* linguist-documentation


### PR DESCRIPTION
This project is measured as predominantly C because of the test files:

https://github.com/cgag/loc/search?l=c

This should exclude them from the stats.

See https://github.com/github/linguist#using-gitattributes