### PR TITLE
Add aliases for clojure dialects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "asa" | "asp" => Asp,
         "asax" | "ascx" | "asmx" | "aspx" | "master" | "sitemap" | "webinfo" => AspNet,
         "in" => Autoconf,
-        "clj" => Clojure,
+        "clj" | "cljs" | "cljc" => Clojure,
 
         "f" | "for" | "ftn" | "f77" | "pfo" => FortranLegacy,
         "f03" | "f08" | "f90" | "f95" => FortranModern,


### PR DESCRIPTION
Adds support for Clojurescript (.cljs) and platform independent Clojure (.cljc) by treating them as pure Clojure (.clj). The dialects are very similar and should not affect line counting.