### PR TITLE
Check for whitespaces between comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,7 @@ pub fn count_normal(filepath: &str,
                 pos += end_len;
                 in_comment = false;
                 // TODO(cgag): should we bother handling whitespace here?
-            } else if !in_comment {
+            } else if !in_comment && !trimmed.chars().nth(pos).unwrap().is_whitespace(){
                 found_code = true;
                 pos += 1;
             } else {


### PR DESCRIPTION
This correct counts lines such as
```
/* comment 1 */ /* comment 2 */
```
as comments