### PR TITLE
Uncover shadowed variable.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,9 +193,9 @@ fn main() {
     let mut by_lang: HashMap<Lang, Vec<FileCount>> = HashMap::new();
     for fc in filecounts {
         match by_lang.entry(fc.lang) {
-            Entry::Occupied(mut by_lang) => by_lang.get_mut().push(fc),
-            Entry::Vacant(by_lang) => {
-                by_lang.insert(vec![fc]);
+            Entry::Occupied(mut elem) => elem.get_mut().push(fc),
+            Entry::Vacant(elem) => {
+                elem.insert(vec![fc]);
             }
         };
     }


### PR DESCRIPTION
Tiny patch just to rename a variable to prevent confusion. The previous implementation covered up the name of the HashMap.

Could be because I'm new to Rust, but I was very confused by what those calls were doing, particularly `by_lang.insert(vec![fc])`
