### PR TITLE
implement support for Gherkin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub enum Lang {
     FortranLegacy,
     FortranModern,
     FSharp,
+    Gherkin,
     Glsl,
     Go,
     Handlebars,
@@ -186,6 +187,7 @@ impl Lang {
             FortranLegacy => "FORTRAN Legacy",
             FortranModern => "FORTRAN Modern",
             FSharp => "F#",
+            Gherkin => "Gherkin",
             Glsl => "GLSL",
             Go => "Go",
             Handlebars => "Handlebars",
@@ -305,6 +307,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "dts" | "dtsi" => DeviceTree,
         "el" | "lisp" | "lsp" | "scm" | "ss" | "rkt" => Lisp,
         "erl" | "hrl" => Erlang,
+        "feature" => Gherkin,
         "fs" | "fsx" => FSharp,
         "vert" | "tesc" | "tese" | "geom" | "frag" | "comp" => Glsl,
         "go" => Go,
@@ -462,8 +465,8 @@ pub fn counter_config_for_lang<'a>(lang: &Lang) -> LineConfig<'a> {
 
         Html | Polly | RubyHtml | XML => html_style,
 
-        BourneShell | Make | Awk | CShell | Makefile | Nim | R | SaltStack | Tcl | Toml |
-        Yaml | Zsh => sh_style,
+        BourneShell | Make | Awk | CShell | Gherkin | Makefile | Nim | R | SaltStack | Tcl |
+        Toml | Yaml | Zsh => sh_style,
 
         // TODO(cgag): not 100% sure that yacc belongs here.
         C | CCppHeader | Rust | Yacc | ActionScript | ColdFusionScript | Css | Cpp | CUDA |

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -116,3 +116,12 @@ const ADA_EXPECTED: Count = Count {
     lines: 4+3,
 };
 test_count![ADA, ADA_EXPECTED, ada_count, ada_code, ada_comment, ada_blank, ada_lines];
+
+const GHERKIN: &'static str = "tests/data/gherkin.feature";
+const GHERKIN_EXPECTED: Count = Count {
+    code: 8,
+    blank: 2,
+    comment: 2,
+    lines: 8+2+2,
+};
+test_count![GHERKIN, GHERKIN_EXPECTED, gherkin_count, gherkin_code, gherkin_comment, gherkin_blank, gherkin_lines];

--- a/tests/data/gherkin.feature
+++ b/tests/data/gherkin.feature
@@ -1,0 +1,12 @@
+Feature: Counting lines of code in Gherkin files
+
+  This is some freeform text information, but it is not a comment.
+  # ...but this is a comment.
+
+  Scenario: File is counted
+   Given a file with extension ".feature"
+    When loc processes it
+    Then it should correctly count the number of lines
+     And it should correctly count the number of comments
+     # And it should solve world hunger
+     And we should not not get ahead of ourselves


### PR DESCRIPTION
Gherkin is a language commonly used for writing BDD style tests, with parsers in a dozen+ different languages. It is part of the Cucumber project.

https://github.com/cucumber/cucumber/wiki/Gherkin