### PR TITLE
Fix Perl identification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "mm" => ObjectiveCpp,
         "nim" => Nim,
         "php" => Php,
-        "pl" => Perl,
+        "pl" | "pm" => Perl,
         "qcl" => Qcl,
         "qml" => Qml,
         "cshtml" => Razor,


### PR DESCRIPTION
Perl scripts are usually .pl, but Perl modules are usually .pm. This just lets
loc also know that .pm is also Perl. Tested on my system and it worked.