### PR TITLE
Fixes #48: Include usage examples for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,111 @@ If you want to install Rust/Cargo, this is probably the easiest way: [https://ww
 You can run `loc` on Windows 10 Anniversary Update build 14393 or later using the [Windows Subsystem for Linux](https://msdn.microsoft.com/de-de/commandline/wsl/install_guide?f=255&MSPPError=-2147217396). Simply download the Linux distribution from the [releases page](https://github.com/cgag/loc/releases), and run it in `bash` using a WSL-compatible path (e.g. `/mnt/c/Users/Foo/Repo/` instead of `C:\Users\Foo\Repo`).
 ```
 
+### Usage
+
+By default, `loc` will count lines of code in a target directory:
+
+``` shell
+$ loc
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+ Lua                      2       387088        24193       193544       169351
+ Rust                     4         1172          111           31         1030
+ C                        4          700           75          155          470
+ Markdown                 2          249           39            0          210
+ Bourne Shell             4          228           41           27          160
+ Ada                      2           53           12            9           32
+ Toml                     1           26            4            2           20
+ Gherkin                  1           12            2            2            8
+ OCaml                    1           13            4            6            3
+ Ruby                     1            4            0            2            2
+ Handlebars               1            4            0            2            2
+--------------------------------------------------------------------------------
+ Total                   23       389549        24481       193780       171288
+--------------------------------------------------------------------------------
+
+```
+
+You can also pass one or many targets for it to inspect
+
+``` shell
+$ loc ci benches
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+ Bourne Shell             4          228           41           27          160
+ Rust                     1           17            4            0           13
+--------------------------------------------------------------------------------
+ Total                    5          245           45           27          173
+--------------------------------------------------------------------------------
+```
+
+To see stats for *each file* parsed, pass the `--files` flag:
+
+```sh
+$ loc --files src
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+ Rust                     2         1028           88           29          911
+--------------------------------------------------------------------------------
+|src/lib.rs                         677           54           19          604
+|src/main.rs                        351           34           10          307
+```
+
+By default, the columns will be sorted by `Code` counted in descending order. You can select a different column to sort
+using the `--sort` flag:
+
+``` shell
+$ loc --files --sort Comment ci
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+ Bourne Shell             4          228           41           27          160
+--------------------------------------------------------------------------------
+|ci/before_deploy.sh                 68           15           13           40
+|ci/install.sh                       60           13            6           41
+|ci/script.sh                        41            8            8           25
+|ci/utils.sh                         59            5            0           54
+
+```
+
+`loc` can also be called with regexes to match and/or exclude files.
+
+``` shell
+$ loc --include 'count'
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+ Rust                     2          144           23            2          119
+--------------------------------------------------------------------------------
+ Total                    2          144           23            2          119
+```
+
+``` shell
+loc --exclude 'sh$'
+--------------------------------------------------------------------------------
+ Language             Files        Lines        Blank      Comment         Code
+--------------------------------------------------------------------------------
+ Lua                      2       387088        24193       193544       169351
+ Rust                     4         1172          111           31         1030
+ C                        4          700           75          155          470
+ Markdown                 2          275           38            0          237
+ Ada                      2           53           12            9           32
+ Toml                     1           26            4            2           20
+ Gherkin                  1           12            2            2            8
+ OCaml                    1           13            4            6            3
+ Handlebars               1            4            0            2            2
+ Ruby                     1            4            0            2            2
+--------------------------------------------------------------------------------
+ Total                   19       389347        24439       193753       171155
+--------------------------------------------------------------------------------
+```
+
+
 ### Known Issues
 Fortran has a rule that comments must start with the first character of a line. I only check if it's the first non-whitespace character of a line. I don't know
 how often this is a problem in real code.  I would think not often.
@@ -27,7 +132,7 @@ how often this is a problem in real code.  I would think not often.
 Comments inside string literals: You can get incorrect counts if your code has something like this:
 
 ```
-x = "/* I haven't slept \ 
+x = "/* I haven't slept \
 for 10 days \
 because that would be too long \
 */";

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
              .help("A single -u won't respect .gitignore (etc.) files. Two -u flags will additionally count hidden files and directories."))
         .arg(Arg::with_name("target")
             .multiple(true)
-            .help("File or directory to count"))
+            .help("File or directory to count (multiple arguments accepted)"))
         .get_matches();
 
     let targets = match matches.values_of("target") {


### PR DESCRIPTION
## Description

- Includes a bunch of usage examples in the README.
- Also tried to make it more explicit in the argument parser that it would accept multiple *target*s.

I looked at the `clap` docs for modifying the usage so that all of this information is emitted on `loc -h`, but it seems like you have to completely overwrite the auto-usage information in order to produce that? 

It's still possible, of course, to do that, but then it seems like you have to remember to change the usage every time you want to add or remove an optional or required argument.