### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ If you want to install Rust/Cargo, this is probably the easiest way: [https://ww
 
 `loc` should now compile on Windows, but you can also run it under Windows using linux emulation:
 
-```
-You can run `loc` on Windows 10 Anniversary Update build 14393 or later using the [Windows Subsystem for Linux](https://msdn.microsoft.com/de-de/commandline/wsl/install_guide?f=255&MSPPError=-2147217396). Simply download the Linux distribution from the [releases page](https://github.com/cgag/loc/releases), and run it in `bash` using a WSL-compatible path (e.g. `/mnt/c/Users/Foo/Repo/` instead of `C:\Users\Foo\Repo`).
-```
+> You can run `loc` on Windows 10 Anniversary Update build 14393 or later using the [Windows Subsystem for Linux](https://msdn.microsoft.com/de-de/commandline/wsl/install_guide?f=255&MSPPError=-2147217396). Simply download the Linux distribution from the [releases page](https://github.com/cgag/loc/releases), and run it in `bash` using a WSL-compatible path (e.g. `/mnt/c/Users/Foo/Repo/` instead of `C:\Users\Foo\Repo`).
 
 ### Usage
 


### PR DESCRIPTION
Previously, the Markdown formatting was not used in the WSL README section as this was wrongly formatted as code.