### PR TITLE
Add "postcss" extension for css lang

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "coffee" => CoffeeScript,
         "cs" => CSharp,
         "csh" => CShell,
-        "css" => Css,
+        "css" | "postcss" => Css,
         "cu" => CUDA,
         "cuh" => CUDAHeader,
         "d" => D,


### PR DESCRIPTION
[Postcss](https://github.com/postcss/postcss) is very popular extension for css, so it would be nice to add it as a synonym.