### PR TITLE
Set the name of the tool to loc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ impl Worker {
 
 fn main() {
 
-    let matches = App::new("count")
+    let matches = App::new("loc")
         .global_settings(&[AppSettings::ColoredHelp])
         .version(crate_version!())
         .author("Curtis Gagliardi <curtis@curtis.io>")


### PR DESCRIPTION
`loc --version` printed `count 0.4.1`, which seemed unintentional.