### PR TITLE
AmbientTalk support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ ignore files with `loc -u`, and include hidden files/dirs with `loc -uu`.
 - ActionScript
 - Ada
 - Agda
+- AmbientTalk
 - ASP
 - ASP.NET
 - Assembly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub enum Lang {
     ActionScript,
     Ada,
     Agda,
+    AmbientTalk,
     Asp,
     AspNet,
     Assembly,
@@ -166,6 +167,7 @@ impl Lang {
             ActionScript => "ActionScript",
             Ada => "Ada",
             Agda => "Agda",
+            AmbientTalk => "AmbientTalk",
             Asp => "ASP",
             AspNet => "ASP.NET",
             Assembly => "Assembly",
@@ -305,6 +307,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "ada" | "adb" | "ads" | "pad" => Ada,
         "agda" => Agda,
         "as" => ActionScript,
+        "at" => AmbientTalk,
         "awk" => Awk,
         "bat" | "btm" | "cmd" => Batch,
         "c" | "ec" | "pgc" => C,
@@ -496,7 +499,7 @@ pub fn counter_config_for_lang<'a>(lang: &Lang) -> LineConfig<'a> {
         | Toml | Yaml | Zsh | Elixir => sh_style,
 
         // TODO(cgag): not 100% sure that yacc belongs here.
-        C | CCppHeader | Rust | Yacc | ActionScript | ColdFusionScript | Css | Cpp | CUDA
+        AmbientTalk | C | CCppHeader | Rust | Yacc | ActionScript | ColdFusionScript | Css | Cpp | CUDA
         | CUDAHeader | CSharp | Dart | DeviceTree | Glsl | Go | Jai | Java | JavaScript | Jsx
         | Kotlin | Less | LinkerScript | ObjectiveC | ObjectiveCpp | Qcl | Sass | Scala | Swift
         | TypeScript | Tsx | UnrealScript | Stylus | Qml | Haxe | Groovy => c_style,


### PR DESCRIPTION
[AmbientTalk is an experimental language by the Vrije Universiteit Brussel](http://soft.vub.ac.be/amop/) for ambient programming.

This might come in handy for those students (usually masters and PhD's) that want to count lines!