### PR TITLE
Don't count extension-less non-scripts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
                 if let Some(ext) = check_shebang(path) {
                     ext
                 } else {
-                    file_name_lower
+                    return Unrecognized;
                 }
             }
         }


### PR DESCRIPTION
Per #115, this seems to fix the issue but still count other things like Makefiles, etc. just fine. 