### PR TITLE
Fix multiline comments for python

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,7 @@ pub fn counter_config_for_lang<'a>(lang: Lang) -> (SmallVec<[&'a str; 3]>, Small
         Perl   => (smallvec!["#"], smallvec![("=pod", "=cut")]),
         Puppet => (smallvec!["#"], smallvec![]),
         Pyret  => (smallvec!["#"], smallvec![("#|", "|#")]),
-        Python => (smallvec!["#"], smallvec![("'''", "'''")]),
+        Python => (smallvec!["#"], smallvec![("'''", "'''"), ("\"\"\"", "\"\"\"")]),
         Ruby   => (smallvec!["#"], smallvec![("=begin", "=end")]),
         Sql    => (smallvec!["--"], smallvec![("/*", "*/")]),
 
@@ -660,7 +660,7 @@ pub fn count(filepath: &str) -> Count {
                     }
                 }
 
-                if pos + start_len <= line_len && &line[pos..pos + start_len] == *start {
+                if pos + start_len <= line_len && &line[pos..pos + start_len] == *start  && (start != end || multi_stack.is_empty()) {
                     pos += start_len;
                     multi_stack.push(*multi);
                     continue;

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -210,3 +210,19 @@ test_count![NESTED_HASKELL,
             nested_haskell_comment,
             nested_haskell_blank,
             nested_haskell_lines];
+
+const PYTHON: &'static str = "tests/data/test.py";
+const PYTHON_EXPECTED: Count = Count {
+    code: 3,
+    blank: 1,
+    comment: 6,
+    lines: 10,
+};
+test_count![PYTHON,
+            PYTHON_EXPECTED,
+            python_count,
+            python_code,
+            python_comment,
+            python_blank,
+            python_lines];
+

--- a/tests/data/test.py
+++ b/tests/data/test.py
@@ -1,0 +1,10 @@
+'''
+This is a module docstring
+'''
+a = 1
+b = 2
+c = 3
+"""
+This is a module docstring
+"""
+


### PR DESCRIPTION
This PR fixes multiline comments for python (and for languages where _begin_ and _end_ strings are the same).
**It does not** fix #111 because python uses the same characters as comments for multiline strings (`"""`, `'''`), but at least it fixes following cases:
```python
'''
This is a module docstring
'''
a = 1
b = 2
c = 3
"""
This is a module docstring
"""
```