### PR TITLE
Add support for Bourne Shell files with .bash extention

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "as" => ActionScript,
         "at" => AmbientTalk,
         "awk" => Awk,
+        "bash" => BourneShell,
         "bat" | "btm" | "cmd" => Batch,
         "c" | "ec" | "pgc" => C,
         "cc" | "cpp" | "cxx" | "c++" | "pcc" => Cpp,


### PR DESCRIPTION
not sure if this should be add next to sh or to keep it sorted like this. 