### PR TITLE
Treat `*.rbi` files as `*.rb` files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,7 +420,7 @@ pub fn lang_from_ext(filepath: &str) -> Lang {
         "arr" => Pyret,
         "py" => Python,
         "r" => R,
-        "rake" | "rb" => Ruby,
+        "rake" | "rb" | "rbi" => Ruby,
         "re" | "rei" => Reason,
         "rhtml" | "erb" => RubyHtml,
         "ron" => Ron,

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -89,6 +89,15 @@ const LUA_EXPECTED: Count = Count {
 };
 test_count![LUA, LUA_EXPECTED, lua_count, lua_code, lua_comment, lua_blank, lua_lines];
 
+const RBI: &'static str = "tests/data/test.rbi";
+const RBI_EXPECTED: Count = Count {
+    code: 5,
+    blank: 2,
+    comment: 2,
+    lines: 9,
+};
+test_count![RBI, RBI_EXPECTED, ruby_count, ruby_code, ruby_comment, ruby_blank, ruby_lines];
+
 const RUBY: &'static str = "tests/data/test.rb";
 const RUBY_EXPECTED: Count = Count {
     code: 2,

--- a/tests/data/test.rbi
+++ b/tests/data/test.rbi
@@ -1,0 +1,9 @@
+# typed: true
+
+class A
+  # comment
+  def foo; end
+
+  sig {returns(Integer)}
+  def bar; end
+end


### PR DESCRIPTION
[Sorbet], the Ruby type checker, uses `*.rbi` files ([Ruby interface files]) to
provide optional type annotations without touching the source `*.rb` files. They
act similar to `*.h` files in C/C++ and `*.d.ts` files in TypeScript.

The syntax of RBI files is a subset of Ruby syntax, so ever line of an RBI file
is effectively a line of Ruby code.

[Sorbet]: https://sorbet.org
[Ruby interface files]: https://sorbet.org/docs/rbi